### PR TITLE
Support boolean type for pipeline

### DIFF
--- a/api/pipeline.md
+++ b/api/pipeline.md
@@ -190,7 +190,7 @@ Authorization: Pandora <auth>
 |group|string|否|指定该消息队列所属的资源池,如果不填写,则说明独享消息队列资源|
 |schema|array|是|相当于关系型数据库表中的`字段集`，当valtype取值为map时，该参数需要嵌套，且嵌套深度最大为5|
 | schema.key|string|是|相当于关系型数据库表的`字段`,</br>命名规则: `^[a-zA-Z_][a-zA-Z0-9_]{0,127}$`,1-128个字符,支持小写字母、数字、下划线；</br>必须以大小写字母或下划线开头|
-| schema.valtype|string|是|描述`key`字段的数据类型,目前仅支持`long`、`date`、`float`、`string`、`array`和`map`,</br>其中`float`的最大精度是`float64`；`array`表示数组类型，数组元素必须为同一类型；`map`表示嵌套类型，类似于json object|
+| schema.valtype|string|是|描述`key`字段的数据类型,目前仅支持`boolean`、`long`、`date`、`float`、`string`、`array`和`map`,</br>其中`boolean`表示布尔类型，默认值为`false`；`float`的最大精度是`float64`；`array`表示数组类型，数组元素必须为同一类型；`map`表示嵌套类型，类似于json object|
 | schema.elemtype|string|否|当数据类型为`array`时，该参数必填，否则将其忽略。该参数表示`array`的元素类型，目前仅支持`long`、`float`、`string`|
 | schema.required|bool|否|描述用户在传输数据时`key`字段是否必填|
 


### PR DESCRIPTION
1、pipeline支持boolean类型，使得pipeline类型系统更加完备，适配json bool类型
2、pipeline boolean类型可以与logdb boolean类型直接对应，不再需要export service作任何转换操作